### PR TITLE
worker: header-based authenticator

### DIFF
--- a/doc/deploy/worker.md
+++ b/doc/deploy/worker.md
@@ -1,18 +1,18 @@
 # Deploy Foulkon Worker
 
  You have to specify configuration file using flag `-config-file`. Using binary file command is `worker -config-file=/path/config.toml`
- 
+
 ## Deploy with docker
 Then, you can run the docker image, mounting (-v) a config.toml inside the container (you could also make a custom Dockerfile with "ADD my-custom-conf.toml /my-custom-conf.toml").
-E.g. 
+E.g.
  ```
  docker run -v /home/myuser/foulkon/config.toml:/worker.toml tecsisa/foulkon worker
  ```
- 
-## Worker configuration file 
+
+## Worker configuration file
  This config file is a TOML file that has several parts:
- 
-### [server] 
+
+### [server]
 | Server   | Server config properties              | Values                     | Default | Optional |
 |----------|---------------------------------------|----------------------------|---------|----------|
 | host     | Worker's hostname.                    | `localhost`                |         | No       |
@@ -22,7 +22,7 @@ E.g.
 
 __Note:__ Don't use Foulkon worker without certificate in production.
 
-### [admin] 
+### [admin]
 | Admin user | Admin user configuration | Values     | Default | Optional |
 |------------|--------------------------|------------|---------|----------|
 | username   | Admin user name.         | `admin`    |         | No       |
@@ -30,7 +30,7 @@ __Note:__ Don't use Foulkon worker without certificate in production.
 
 __Note:__ Use a strong password for admin user in production.
 
-### [logger] 
+### [logger]
 | Logger | Logger configuration properties.                        | Values                                                | Default   | Optional                    |
 |--------|---------------------------------------------------------|-------------------------------------------------------|-----------|-----------------------------|
 | type   | Type of logger to use.                                  | `file`, `default`                                     | `default` | Yes                         |
@@ -49,19 +49,24 @@ __Note:__ Use a strong password for admin user in production.
 | idleconns      | Idle connection number.                                      | `10`                                                                   | 5       | Yes      |
 | maxopenconns   | Max open connection number.                                  | `20`                                                                   | 20      | Yes      |
 | connttl        | Timeout for conenctions                                      | `200`                                                                  | 300     | Yes      |
- 
+
 ### [authenticator]
-| Authenticator | Authenticatior connector configuration properties        | Values | Default | Optional |
-|---------------|----------------------------------------------------------|--------|---------|----------|
-| type          | Type of connector that will be used. Only `oidc` at now. | `oidc` |         | No       |
+| Authenticator | Authenticator connector configuration properties | Values           | Default | Optional |
+|---------------|--------------------------------------------------|------------------|---------|----------|
+| type          | Type of connector that will be used.             | `oidc`, `header` | None    | No       |
+
+#### [authenticator.name]
+| Header authenticator | Header authenticator connector configuration properties | Values           | Default | Optional |
+|----------------------|---------------------------------------------------------|------------------|---------|----------|
+| name                 | Trusted request header                                  | `X-Remote-User`  | None    | No       |
 
 ## OIDC Providers
-The worker reads configuration from database at startup, and configures authenticator to use configured OIDC Providers with its clients.
-If you want to add, update o delete OIDC Providers you have to use the [OIDC Provider API](../api/oidc_provider.md). 
-If you change OIDC Providers you will need to restart the worker servers to take effect the changes.
+The worker reads configuration from database at startup, and when configured to use the OIDC authenticator, initializes it to use configured OIDC Providers with its clients.
+If you want to add, update or delete OIDC Providers you have to use the [OIDC Provider API](../api/oidc_provider.md).
+If you change OIDC Providers you will need to restart the worker servers to have the changes take effect.
 
 ## Current configuration
-The worker server has an endpoint to see what configuration is active at this time, only for admin access. 
+The worker server has an endpoint to see what configuration is active at this time, only for admin access.
 
 #### Curl Example
 

--- a/middleware/auth/connector.go
+++ b/middleware/auth/connector.go
@@ -61,7 +61,7 @@ func (a *AuthenticatorMiddleware) GetInfo(r *http.Request, mc *middleware.Middle
 	mc.UserId, mc.Admin = a.getAuthenticatedUser(r)
 }
 
-// GetAuthenticatedUser retrieves user from request
+// getAuthenticatedUser retrieves user from request
 func (a *AuthenticatorMiddleware) getAuthenticatedUser(r *http.Request) (string, bool) {
 	if isAdmin(r, a.adminUser, a.adminPassword) {
 		return a.adminUser, true

--- a/middleware/auth/header/header.go
+++ b/middleware/auth/header/header.go
@@ -1,0 +1,46 @@
+package header
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Tecsisa/foulkon/api"
+	"github.com/Tecsisa/foulkon/middleware"
+	"github.com/Tecsisa/foulkon/middleware/auth"
+)
+
+// HeaderAuthConnector represents a connector that implements interface of auth connector
+type HeaderAuthConnector struct {
+	header string
+}
+
+// InitHeaderConnector initializes Header connector configuration
+func InitHeaderConnector(header string) auth.AuthConnector {
+	return &HeaderAuthConnector{
+		header: header,
+	}
+}
+
+// Authenticate retrieves auth header from request and returns its value
+func (h HeaderAuthConnector) Authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		hdr := r.Header.Get(h.header)
+		if hdr == "" {
+			apiError := &api.Error{
+				Code:    api.AUTHENTICATION_API_ERROR,
+				Message: "header authenticator: no auth header found",
+			}
+			requestID := r.Header.Get(middleware.REQUEST_ID_HEADER)
+			api.LogOperationError(requestID, "", apiError)
+			http.Error(rw, fmt.Sprintf("Error %v", apiError.Message), http.StatusUnauthorized)
+		} else {
+			r.Header.Add(middleware.USER_ID_HEADER, hdr)
+			next.ServeHTTP(rw, r)
+		}
+	})
+}
+
+// HeaderAuthConnector retrieves user from header
+func (h HeaderAuthConnector) RetrieveUserID(r http.Request) string {
+	return r.Header.Get(h.header)
+}

--- a/middleware/auth/oidc/oidc.go
+++ b/middleware/auth/oidc/oidc.go
@@ -61,7 +61,7 @@ func InitOIDCConnector(oidcProviders []api.OidcProvider) (auth.AuthConnector, er
 
 }
 
-// This method retrieves data from request an checks if user is correctly authenticated
+// This method retrieves data from request and checks if user is correctly authenticated
 func (c OIDCAuthConnector) Authenticate(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userHandler := func(u *openid.User, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
With the following `[authenticator]` configuration,

    [authenticator]
    type = "header"
      [authenticator.header]
      name = "X-Remote-User"

worker will _trust_ this header, and take its value as the authenticated
user's ID.

An example use case of this feature is a service setup where an upstream
service already checks authentication, and passed that along in a
request header. Of course, incoming requests (edge of the service
network) will need to have that header stripped.

Real-world examples are Kubernetes' _Authenticating Proxy_, see here:
https://kubernetes.io/docs/admin/authentication/#authenticating-proxy
